### PR TITLE
Add HEVC-like CABAC residual block demo

### DIFF
--- a/HM-master/source/App/utils/cabac_block_demo.cpp
+++ b/HM-master/source/App/utils/cabac_block_demo.cpp
@@ -1,0 +1,102 @@
+/* The copyright in this software is being made available under the BSD
+ * License, included below. This software may be subject to other third party
+ * and contributor rights, including patent rights, and no such rights are
+ * granted under this license.
+ *
+ * Copyright (c) 2010-2022, ITU/ISO/IEC
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *  * Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *  * Neither the name of the ITU/ISO/IEC nor the names of its contributors may
+ *    be used to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+* THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "TLibCommon/TComBitStream.h"
+#include "TLibEncoder/TEncBinCoderCABAC.h"
+#include "TLibDecoder/TDecBinCoderCABAC.h"
+#include <vector>
+#include <iostream>
+
+/** Simple demonstration of encoding and decoding an n*n block using CABAC.
+ *  Each sample is coded using bypass bins (encodeBinsEP/decodeBinsEP).
+ */
+
+static void encodeBlockCABAC(const std::vector<uint8_t>& block, int n, TComOutputBitstream& bitstream)
+{
+  TEncBinCABAC cabac;
+  cabac.init(&bitstream);
+  cabac.start();
+
+  for (int i = 0; i < n * n; ++i)
+  {
+    cabac.encodeBinsEP(block[i], 8); // encode one byte using bypass mode
+  }
+
+  cabac.finish();
+}
+
+static void decodeBlockCABAC(std::vector<uint8_t>& block, int n, TComInputBitstream& bitstream)
+{
+  TDecBinCABAC cabac;
+  cabac.init(&bitstream);
+  cabac.start();
+
+  for (int i = 0; i < n * n; ++i)
+  {
+    UInt val = 0;
+    cabac.decodeBinsEP(val, 8);
+    block[i] = static_cast<uint8_t>(val);
+  }
+
+  cabac.finish();
+}
+
+int main()
+{
+  int n = 4;
+  std::vector<uint8_t> src(n * n);
+  for (int i = 0; i < n * n; ++i)
+  {
+    src[i] = static_cast<uint8_t>(i);
+  }
+
+  TComOutputBitstream out;
+  encodeBlockCABAC(src, n, out);
+
+  TComInputBitstream in;
+  in.getFifo() = out.getFIFO();
+  in.resetToStart();
+
+  std::vector<uint8_t> dst(n * n);
+  decodeBlockCABAC(dst, n, in);
+
+  for (int y = 0; y < n; ++y)
+  {
+    for (int x = 0; x < n; ++x)
+    {
+      std::cout << int(dst[y * n + x]) << (x + 1 == n ? '\n' : ' ');
+    }
+  }
+  return 0;
+}
+

--- a/HM-master/source/App/utils/cabac_coeff_blocks_demo.cpp
+++ b/HM-master/source/App/utils/cabac_coeff_blocks_demo.cpp
@@ -1,0 +1,124 @@
+#include "TLibCommon/TComBitStream.h"
+#include "TLibEncoder/TEncBinCoderCABAC.h"
+#include "TLibDecoder/TDecBinCoderCABAC.h"
+#include <vector>
+#include <iostream>
+#include <cstdlib>
+
+// Encode multiple n*n residual coefficient blocks using CABAC with simple context modelling
+static void encodeCoeffBlocksCABAC(const std::vector<std::vector<int16_t>>& blocks, int n, TComOutputBitstream& bitstream)
+{
+    TEncBinCABAC cabac;
+    cabac.init(&bitstream);
+    cabac.start();
+
+    ContextModel ctxSig;
+    ContextModel ctxGt1;
+    ctxSig.init(0, 0);
+    ctxGt1.init(0, 0);
+
+    for (const auto& block : blocks)
+    {
+        for (int i = 0; i < n * n; ++i)
+        {
+            int coeff = block[i];
+            UInt nonZero = coeff != 0;
+            cabac.encodeBin(nonZero, ctxSig);
+
+            if (nonZero)
+            {
+                UInt gt1 = std::abs(coeff) > 1;
+                cabac.encodeBin(gt1, ctxGt1);
+                UInt sign = coeff < 0;
+                cabac.encodeBinEP(sign);
+
+                UInt magMinus1 = std::abs(coeff) - 1;
+                cabac.encodeBinsEP(magMinus1, 8); // encode magnitude minus 1 with 8 bypass bits
+            }
+        }
+    }
+
+    cabac.finish();
+}
+
+static void decodeCoeffBlocksCABAC(std::vector<std::vector<int16_t>>& blocks, int n, TComInputBitstream& bitstream)
+{
+    TDecBinCABAC cabac;
+    cabac.init(&bitstream);
+    cabac.start();
+
+    ContextModel ctxSig;
+    ContextModel ctxGt1;
+    ctxSig.init(0, 0);
+    ctxGt1.init(0, 0);
+
+    for (auto& block : blocks)
+    {
+        for (int i = 0; i < n * n; ++i)
+        {
+            UInt nonZero = 0;
+            cabac.decodeBin(nonZero, ctxSig);
+
+            if (nonZero)
+            {
+                UInt gt1 = 0;
+                cabac.decodeBin(gt1, ctxGt1);
+                UInt sign = 0;
+                cabac.decodeBinEP(sign);
+
+                UInt magMinus1 = 0;
+                cabac.decodeBinsEP(magMinus1, 8);
+
+                int val = int(magMinus1 + 1);
+                if (sign)
+                    val = -val;
+                block[i] = val;
+            }
+            else
+            {
+                block[i] = 0;
+            }
+        }
+    }
+
+    cabac.finish();
+}
+
+int main()
+{
+    const int n = 4;
+    const int numBlocks = 2;
+    std::vector<std::vector<int16_t>> src(numBlocks, std::vector<int16_t>(n * n));
+
+    for (auto& block : src)
+    {
+        for (int i = 0; i < n * n; ++i)
+        {
+            block[i] = (i % 5 == 0) ? -(i + 1) : (i % 3); // simple pattern
+        }
+    }
+
+    TComOutputBitstream out;
+    encodeCoeffBlocksCABAC(src, n, out);
+
+    TComInputBitstream in;
+    in.getFifo() = out.getFIFO();
+    in.resetToStart();
+
+    std::vector<std::vector<int16_t>> dst(numBlocks, std::vector<int16_t>(n * n));
+    decodeCoeffBlocksCABAC(dst, n, in);
+
+    for (int b = 0; b < numBlocks; ++b)
+    {
+        std::cout << "Block " << b << "\n";
+        for (int y = 0; y < n; ++y)
+        {
+            for (int x = 0; x < n; ++x)
+            {
+                std::cout << dst[b][y * n + x] << (x + 1 == n ? '\n' : ' ');
+            }
+        }
+    }
+    return 0;
+}
+

--- a/HM-master/source/App/utils/cabac_residual_block.cpp
+++ b/HM-master/source/App/utils/cabac_residual_block.cpp
@@ -1,0 +1,138 @@
+#include "TLibCommon/TComBitStream.h"
+#include "TLibEncoder/TEncBinCoderCABAC.h"
+#include "TLibDecoder/TDecBinCoderCABAC.h"
+#include <vector>
+#include <iostream>
+#include <cstdlib>
+
+/**
+ * Encode a single n*n residual coefficient block using simple HEVC-like
+ * context modelling. This is a pedagogical example and does not implement
+ * the full standard but illustrates the basic CABAC procedure.
+ */
+static void encodeResidualBlockCABAC(const std::vector<int16_t>& block, int n, TComOutputBitstream& bitstream)
+{
+    TEncBinCABAC cabac;
+    cabac.init(&bitstream);
+    cabac.start();
+
+    // determine last significant coefficient in scan order
+    int last = -1;
+    for (int i = n*n - 1; i >= 0; --i)
+    {
+        if (block[i] != 0)
+        {
+            last = i;
+            break;
+        }
+    }
+    if (last < 0)
+    {
+        std::cerr << "Block has no non-zero coefficients" << std::endl;
+        std::exit(1);
+    }
+
+    // encode last coefficient position in unary form
+    ContextModel ctxLastX, ctxLastY;
+    ctxLastX.init(0,0);
+    ctxLastY.init(0,0);
+    int posX = last % n;
+    int posY = last / n;
+    for (int i = 0; i < posX; ++i) cabac.encodeBin(1, ctxLastX);
+    cabac.encodeBin(0, ctxLastX);
+    for (int i = 0; i < posY; ++i) cabac.encodeBin(1, ctxLastY);
+    cabac.encodeBin(0, ctxLastY);
+
+    ContextModel ctxSig, ctxGt1;
+    ctxSig.init(0,0);
+    ctxGt1.init(0,0);
+
+    for (int idx = 0; idx <= last; ++idx)
+    {
+        bool sig = block[idx] != 0;
+        cabac.encodeBin(sig, ctxSig);
+        if (sig)
+        {
+            int absval = std::abs(block[idx]);
+            bool gt1 = absval > 1;
+            cabac.encodeBin(gt1, ctxGt1);
+            cabac.encodeBinEP(block[idx] < 0); // sign
+            unsigned mag = gt1 ? (absval - 2) : (absval - 1);
+            for (int b = 7; b >= 0; --b)
+                cabac.encodeBinEP((mag >> b) & 1);
+        }
+    }
+
+    cabac.finish();
+}
+
+static void decodeResidualBlockCABAC(std::vector<int16_t>& block, int n, TComInputBitstream& bitstream)
+{
+    TDecBinCABAC cabac;
+    cabac.init(&bitstream);
+    cabac.start();
+
+    ContextModel ctxLastX, ctxLastY;
+    ctxLastX.init(0,0);
+    ctxLastY.init(0,0);
+    int posX = 0;
+    while (cabac.decodeBin(ctxLastX)) ++posX;
+    int posY = 0;
+    while (cabac.decodeBin(ctxLastY)) ++posY;
+    int last = posY * n + posX;
+
+    ContextModel ctxSig, ctxGt1;
+    ctxSig.init(0,0);
+    ctxGt1.init(0,0);
+
+    block.assign(n*n, 0);
+    for (int idx = 0; idx <= last; ++idx)
+    {
+        unsigned sig = 0;
+        cabac.decodeBin(sig, ctxSig);
+        if (sig)
+        {
+            unsigned gt1 = 0;
+            cabac.decodeBin(gt1, ctxGt1);
+            unsigned sign = 0;
+            cabac.decodeBinEP(sign);
+            unsigned mag = 0;
+            for (int b = 7; b >= 0; --b)
+            {
+                unsigned bit = 0;
+                cabac.decodeBinEP(bit);
+                mag = (mag << 1) | bit;
+            }
+            int absval = gt1 ? (mag + 2) : (mag + 1);
+            block[idx] = sign ? -absval : absval;
+        }
+    }
+
+    cabac.finish();
+}
+
+int main()
+{
+    int n = 4; // try 4x4 block
+    std::vector<int16_t> src(n*n);
+    for (int i = 0; i < n*n; ++i)
+        src[i] = (i%5==0)?-(i+1):(i%3);
+
+    TComOutputBitstream bs;
+    encodeResidualBlockCABAC(src, n, bs);
+
+    TComInputBitstream in;
+    in.getFifo() = bs.getFIFO();
+    in.resetToStart();
+
+    std::vector<int16_t> dst;
+    decodeResidualBlockCABAC(dst, n, in);
+
+    for (int y = 0; y < n; ++y)
+    {
+        for (int x = 0; x < n; ++x)
+            std::cout << dst[y*n+x] << (x+1==n? '\n':' ');
+    }
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add `cabac_residual_block.cpp` demo to show how to encode and decode an `n x n` residual block using CABAC with simple context modelling

## Testing
- `make` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_683fd0b67050832f8cfe9c2df29cbb70